### PR TITLE
Remove email on signup

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,11 +9,6 @@
   </div>
 
   <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
     <%= f.label :password %>
     <% if @minimum_password_length %>
     <em>(<%= @minimum_password_length %> characters minimum)</em>

--- a/cypress/integration/user_signup.spec.js
+++ b/cypress/integration/user_signup.spec.js
@@ -1,17 +1,29 @@
 describe('User signup', () => {
-  it('signs up', () => {
-    // if the user is already there, this will fail validation
+  const username = 'leeroy_jenkins'
+  const password = 'Password1!'
+
+  before(() => {
     cy.request(
       'delete',
       '/test/users/destroy_username', {
-        'username':'leeroy_jenkins'
+        'username': username
     })
+  })
 
+  afterEach(() => {
+    cy.request(
+      'delete',
+      '/test/users/destroy_username', {
+        'username':username
+    })
+  })
+
+  it('signs up', () => {
     cy.visit('/')
     cy.get('#nav-sign-up').click()
-    cy.get('#user_username').type('leeroy_jenkins')
-    cy.get('#user_password').type('Password1!')
-    cy.get('#user_password_confirmation').type('Password1!')
+    cy.get('#user_username').type(username)
+    cy.get('#user_password').type(password)
+    cy.get('#user_password_confirmation').type(password)
     cy.get("[type=submit]").click()
 
     cy.url()
@@ -20,12 +32,27 @@ describe('User signup', () => {
     cy.get('body')
       .should('contain', 'successful')
       .should('contain', 'Logged in')
+      .should('contain', 'leeroy_jenkins')
+  })
 
-    // cleanup
-    cy.request(
-      'delete',
-      '/test/users/destroy_username', {
-        'username':'leeroy_jenkins'
-    })
+  // Well apparently we can't tab in cypress. But this will be a little
+  // different than the first test. TODO - update when you can.
+  it('signs up with keyboard only', () => {
+    cy.visit('/')
+    cy.get('#nav-sign-up').click()
+    cy.focused().should('have.id', 'user_username')
+    cy.get('#user_username').focus().type(username)
+
+    cy.get('#user_password').focus().type(password)
+    cy.get('#user_password_confirmation').focus().type(password)
+    cy.get("[type=submit]").focus().type(`{enter}`)
+
+    cy.url()
+      .should('eq', 'http://localhost:3000/')
+
+    cy.get('body')
+      .should('contain', 'successful')
+      .should('contain', 'Logged in')
+      .should('contain', 'leeroy_jenkins')
   })
 })


### PR DESCRIPTION
I don't like both those things there. You don't know what's required and
what's not.. Keep it simple. We can add a 'confirm with email' later
on.

Also, added a keyboard signup test with this. Which isn't, really. But
it's slightly different, using 'focus'. Because you can't tab. Bummer.